### PR TITLE
Add comprehensive SEO and Altmetric tracking support

### DIFF
--- a/blog/apic-docetaxel-prediction.html
+++ b/blog/apic-docetaxel-prediction.html
@@ -4,8 +4,72 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Deep Dive: AI Classifier to Predict Docetaxel Benefit in Prostate Cancer - Sebastian Medina</title>
+
+    <!-- SEO Meta Tags -->
+    <meta name="description" content="A detailed analysis of our Clinical Cancer Research paper on using artificial intelligence to predict which prostate cancer patients will benefit from docetaxel chemotherapy.">
+    <meta name="author" content="Sebastian Medina">
+    <meta name="keywords" content="computational pathology, prostate cancer, precision oncology, APIC, docetaxel, AI, machine learning, biomarker">
+    <meta name="citation_title" content="A Computational Pathology Model to Predict Docetaxel Benefit in Localized High-Risk and Metastatic Prostate Cancer">
+    <meta name="citation_author" content="Medina, Sebastian">
+    <meta name="citation_publication_date" content="2025">
+    <meta name="citation_journal_title" content="Clinical Cancer Research">
+    <meta name="citation_doi" content="10.1158/1078-0432.CCR-25-3327">
+
+    <!-- Open Graph Meta Tags for Social Sharing -->
+    <meta property="og:title" content="Deep Dive: AI Classifier to Predict Docetaxel Benefit in Prostate Cancer">
+    <meta property="og:description" content="Analysis of our Clinical Cancer Research paper on AI-based predictive biomarkers for prostate cancer treatment selection.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://srmedinac.github.io/blog/apic-docetaxel-prediction.html">
+    <meta property="og:site_name" content="Sebastian Medina">
+    <meta property="article:published_time" content="2025-01-05">
+    <meta property="article:author" content="Sebastian Medina">
+    <meta property="article:tag" content="computational pathology">
+    <meta property="article:tag" content="prostate cancer">
+    <meta property="article:tag" content="precision oncology">
+
+    <!-- Twitter Card Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Deep Dive: AI Classifier to Predict Docetaxel Benefit in Prostate Cancer">
+    <meta name="twitter:description" content="Analysis of our Clinical Cancer Research paper on AI-based predictive biomarkers for prostate cancer treatment selection.">
+
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://srmedinac.github.io/blog/apic-docetaxel-prediction.html">
+
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+
+    <!-- Structured Data for Search Engines and Altmetric -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BlogPosting",
+      "headline": "Deep Dive: An AI-Based Pathology Classifier to Predict Docetaxel Benefit in Prostate Cancer",
+      "author": {
+        "@type": "Person",
+        "name": "Sebastian Medina",
+        "url": "https://srmedinac.github.io"
+      },
+      "datePublished": "2025-01-05",
+      "description": "A detailed analysis of our Clinical Cancer Research paper on using artificial intelligence to predict which prostate cancer patients will benefit from docetaxel chemotherapy.",
+      "keywords": "computational pathology, prostate cancer, precision oncology, APIC, docetaxel",
+      "citation": {
+        "@type": "ScholarlyArticle",
+        "name": "A Computational Pathology Model to Predict Docetaxel Benefit in Localized High-Risk and Metastatic Prostate Cancer",
+        "author": [
+          {"@type": "Person", "name": "Sebastian Medina"},
+          {"@type": "Person", "name": "Naoto Tokuyama"},
+          {"@type": "Person", "name": "Kamal Hammouda"}
+        ],
+        "datePublished": "2025",
+        "publisher": {
+          "@type": "Organization",
+          "name": "Clinical Cancer Research"
+        },
+        "sameAs": "https://doi.org/10.1158/1078-0432.CCR-25-3327",
+        "identifier": "10.1158/1078-0432.CCR-25-3327"
+      }
+    }
+    </script>
 </head>
 <body>
     <nav class="navbar">

--- a/blog/blog-post-template.html
+++ b/blog/blog-post-template.html
@@ -4,6 +4,31 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Your Post Title - Sebastian Medina</title>
+
+    <!-- SEO Meta Tags - UPDATE THESE FOR YOUR POST -->
+    <meta name="description" content="Brief description of your blog post">
+    <meta name="author" content="Sebastian Medina">
+    <meta name="keywords" content="keyword1, keyword2, keyword3">
+
+    <!-- If referencing a paper, add citation meta tags (uncomment and update) -->
+    <!--
+    <meta name="citation_title" content="Your Paper Title">
+    <meta name="citation_author" content="Medina, Sebastian">
+    <meta name="citation_publication_date" content="2025">
+    <meta name="citation_journal_title" content="Journal Name">
+    <meta name="citation_doi" content="10.xxxx/xxxxx">
+    -->
+
+    <!-- Open Graph for Social Sharing - UPDATE THESE -->
+    <meta property="og:title" content="Your Post Title">
+    <meta property="og:description" content="Brief description">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://srmedinac.github.io/blog/your-slug.html">
+    <meta property="article:published_time" content="2025-01-15">
+
+    <!-- Canonical URL - UPDATE THIS -->
+    <link rel="canonical" href="https://srmedinac.github.io/blog/your-slug.html">
+
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,27 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sebastian Medina - Researcher</title>
+
+    <!-- SEO Meta Tags -->
+    <meta name="description" content="Sebastian Medina - PhD student in Biomedical Engineering at Georgia Tech and Emory University. Developing AI-based precision oncology and computational pathology for advanced prostate cancer.">
+    <meta name="author" content="Sebastian Medina">
+    <meta name="keywords" content="Sebastian Medina, computational pathology, AI, machine learning, prostate cancer, precision oncology, biomedical engineering, Georgia Tech, Emory">
+
+    <!-- Open Graph Meta Tags -->
+    <meta property="og:title" content="Sebastian Medina - Researcher">
+    <meta property="og:description" content="PhD student in Biomedical Engineering developing AI-based precision oncology for advanced prostate cancer">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://srmedinac.github.io/">
+    <meta property="og:site_name" content="Sebastian Medina">
+
+    <!-- Twitter Card Meta Tags -->
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Sebastian Medina - Researcher">
+    <meta name="twitter:description" content="PhD student in Biomedical Engineering developing AI-based precision oncology for advanced prostate cancer">
+
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://srmedinac.github.io/">
+
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://srmedinac.github.io/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://srmedinac.github.io/</loc>
+    <lastmod>2025-01-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://srmedinac.github.io/index.html</loc>
+    <lastmod>2025-01-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://srmedinac.github.io/blog/apic-docetaxel-prediction.html</loc>
+    <lastmod>2025-01-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
- Add citation meta tags (citation_doi, citation_title, etc.) to blog post
- Include Open Graph and Twitter Card meta tags for social sharing
- Add Schema.org structured data (BlogPosting, ScholarlyArticle)
- Create sitemap.xml for search engine indexing
- Create robots.txt to guide crawlers
- Add SEO meta tags to homepage
- Update blog template with SEO guidelines for future posts

This enables Altmetric to track blog mentions of publications and improves discoverability on search engines and social media platforms.